### PR TITLE
Revert "Sanitize item names further"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,3 @@
-### 1.2.4 - 2023-02-25 - The One Where IKELOS Weapons Maybe Work
-
-- Weapons with periods AND underscores (IKELOS weapons) are now parsed even better.
-- If a weapon contains a shorthand for a weapon type (IKELOS SMG) is handled since the code no longer only performs one type of search or the other. It will do both types and if a weapon name was matched, it'll override any generic weapon search.
-
 ### 1.2.3 - 2022-11-25 - Parsing Issues
 
 - Weapons with periods in their name (IKELOS weapons, a few others) are now parsed correctly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 1.2.5 - 2023-02-27 - The Reversion
+- Revert previous change since it broke generic queries and item pulls (by weapon/energy type, etc.)
+
+### 1.2.4 - 2023-02-25 - The One Where IKELOS Weapons Maybe Work
+
+- Weapons with periods AND underscores (IKELOS weapons) are now parsed even better.
+- If a weapon contains a shorthand for a weapon type (IKELOS SMG) is handled since the code no longer only performs one type of search or the other. It will do both types and if a weapon name was matched, it'll override any generic weapon search.
+
 ### 1.2.3 - 2022-11-25 - Parsing Issues
 
 - Weapons with periods in their name (IKELOS weapons, a few others) are now parsed correctly

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "voice-dim",
-  "version": "1.2.4",
+  "version": "1.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "voice-dim",
-      "version": "1.2.4",
+      "version": "1.1.3",
       "license": "ISC",
       "dependencies": {
         "annyang": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voice-dim",
-  "version": "1.2.4",
+  "version": "1.2.3",
   "description": "Perform common DIM actions by using speech recognition.",
   "main": "dist/chrome/js/voice-dim.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voice-dim",
-  "version": "1.2.3",
+  "version": "1.2.5",
   "description": "Perform common DIM actions by using speech recognition.",
   "main": "dist/chrome/js/voice-dim.js",
   "scripts": {

--- a/public/manifest.chrome.json
+++ b/public/manifest.chrome.json
@@ -1,7 +1,7 @@
 {
   "name": "Voice DIM",
   "description": "Control DIM with your voice.",
-  "version": "1.2.3",
+  "version": "1.2.5",
   "manifest_version": 3,
   "background": {
     "service_worker": "js/background.js"

--- a/public/manifest.chrome.json
+++ b/public/manifest.chrome.json
@@ -1,7 +1,7 @@
 {
   "name": "Voice DIM",
   "description": "Control DIM with your voice.",
-  "version": "1.2.4",
+  "version": "1.2.3",
   "manifest_version": 3,
   "background": {
     "service_worker": "js/background.js"

--- a/public/manifest.firefox.json
+++ b/public/manifest.firefox.json
@@ -1,7 +1,7 @@
 {
   "name": "Voice DIM",
   "description": "Control DIM with your voice.",
-  "version": "1.2.4",
+  "version": "1.2.3",
   "manifest_version": 2,
   "background": {
     "scripts": ["js/background.js"]

--- a/public/manifest.firefox.json
+++ b/public/manifest.firefox.json
@@ -1,7 +1,7 @@
 {
   "name": "Voice DIM",
   "description": "Control DIM with your voice.",
-  "version": "1.2.3",
+  "version": "1.2.5",
   "manifest_version": 2,
   "background": {
     "scripts": ["js/background.js"]

--- a/src/ts/background.ts
+++ b/src/ts/background.ts
@@ -38,9 +38,9 @@ chrome.runtime.onMessage.addListener((data: any, sender: chrome.runtime.MessageS
   }
 });
 
-// chrome.runtime.onInstalled.addListener(() => {
-//   openOptionsPage();
-// });
+chrome.runtime.onInstalled.addListener(() => {
+  openOptionsPage();
+});
 
 async function openOptionsPage() {
   const [optionsTab] = await chrome.tabs.query({

--- a/src/ts/voiceDim.ts
+++ b/src/ts/voiceDim.ts
@@ -141,19 +141,6 @@ const otherQueries = {
   'has no notes': '-is:hasnotes',
 };
 
-const numberMap = {
-  1: 'one',
-  2: 'two',
-  3: 'three',
-  4: 'four',
-  5: 'five',
-  6: 'six',
-  7: 'seven',
-  8: 'eight',
-  9: 'nine',
-  0: 'zero',
-};
-
 function setSearchBar() {
   return document.getElementsByName('filter').length > 0
     ? <HTMLInputElement>document.getElementsByName('filter')[0]
@@ -275,32 +262,33 @@ async function handleItemMovement(query: string, action: string): Promise<void> 
 }
 
 async function getItemToMove(query: string): Promise<Element | null> {
+  let itemToMove: Element | null = null;
   let splitQuery = query.split(' with ').map((x) => x.trim());
   let nonPerkQuery = getGenericQuery(splitQuery[0]);
 
   const perkQuery = splitQuery.length > 1 && splitQuery[1] !== '' ? getPerkQuery(splitQuery[1]) : '';
 
   // getting a specific weapon
-  // if (nonPerkQuery === '') {
-  const availableItems = getAllTransferableItems();
-  const itemToGet = getClosestMatch(Object.keys(availableItems), splitQuery[0]);
-
-  if (itemToGet !== null && itemToGet.match !== '') {
+  if (nonPerkQuery === '') {
+    const availableItems = getAllTransferableItems();
+    const itemToGet = getClosestMatch(Object.keys(availableItems), splitQuery[0]);
+    if (!itemToGet) return null;
     const fullName = availableItems[itemToGet.match].name;
     debugLog('voice dim', { itemToGet });
     await populateSearchBar(`${perkQuery} name:"${fullName}"`.trim());
     const visibleItems = getVisibleItems();
-    return visibleItems[0];
+    itemToMove = visibleItems[0];
   }
-
   // Getting a generic weapon (solar grenade launcher, kinetic handcannon, etc.)
-  nonPerkQuery += ` ${perkQuery} -is:incurrentchar -is:postmaster`;
-  await populateSearchBar(nonPerkQuery);
-  const filteredItems = getVisibleItems();
-  if (filteredItems.length > 0) {
-    return filteredItems[0];
+  else {
+    nonPerkQuery += ` ${perkQuery} -is:incurrentchar -is:postmaster`;
+    await populateSearchBar(nonPerkQuery);
+    const filteredItems = getVisibleItems();
+    if (filteredItems.length > 0) {
+      itemToMove = filteredItems[0];
+    }
   }
-  return null;
+  return itemToMove;
 }
 
 async function transferItem(item: Element) {
@@ -436,20 +424,12 @@ function getAllTransferableItems(): Record<string, { name: string; item: Element
     const filteredItems = getVisibleItems(result);
     filteredItems.forEach((item) => {
       const split = (<HTMLElement>item).title.split('\n');
-      const sanitized = split[0].replaceAll(/[\._]/g, ' ');
+      const sanitized = split[0].replaceAll('.', '');
       items[sanitized] = { name: split[0], item };
-      items[getSpelledNumbers(split[0])] = { name: split[0], item };
     });
   }
 
   return items;
-}
-
-function getSpelledNumbers(itemName: string) {
-  for (let i = 0; i < 10; i++) {
-    itemName.replaceAll(`${i}`, ' ');
-  }
-  return itemName;
 }
 
 type FuseMatch = {


### PR DESCRIPTION
Reverts mlsof21/voice-dim#30

Broke general query item pulls (ex. pulling by energy/weapon type, `solar handcannon`, `void smg`, etc). Tends to pull a specific weapon no matter what.... Really annoying.
